### PR TITLE
Preserve properties

### DIFF
--- a/coap/coap-request.js
+++ b/coap/coap-request.js
@@ -35,13 +35,6 @@ module.exports = function(RED) {
             return payload;
         }
 
-        // this is for testing purposes- payloadDecodedHandler should be set by test code to inspect the payload
-        node.payloadDecodedHandler = function(payload) {};
-
-        function onPayloadDecoded(payload) { 
-            node.payloadDecodedHandler(payload);
-        }
-
         function _onCborDecode(err, data) {
             if (err) {
                 return false;
@@ -50,7 +43,6 @@ module.exports = function(RED) {
             node.send({
                 payload: payload,
             });
-            onPayloadDecoded(payload);
         }
 
         function _makeRequest(msg) {
@@ -58,6 +50,7 @@ module.exports = function(RED) {
             reqOpts.method = ( node.options.method || msg.method || 'GET' ).toUpperCase();
             reqOpts.headers = {};
             reqOpts.headers['Content-Format'] = node.options.contentFormat;
+
             function _onResponse(res) {
                 function _onResponseData(data) {
                     var payload = null;
@@ -65,19 +58,16 @@ module.exports = function(RED) {
                         node.send({
                             payload: data,
                         });
-                        onPayloadDecoded(data);
                     } else if (res.headers['Content-Format'] === 'text/plain') {
                         payload = data.toString();
                         node.send({
                             payload: payload,
                         });
-                        onPayloadDecoded(payload);
                     } else if (res.headers['Content-Format'] === 'application/json') {
                         payload = JSON.parse(data.toString());
                         node.send({
                             payload: payload,
                         });
-                        onPayloadDecoded(payload);
                     } else if (res.headers['Content-Format'] === 'application/cbor') {
                         cbor.decodeAll(data, _onCborDecode);
                     } else if (res.headers['Content-Format'] === 'application/link-format') {
@@ -85,12 +75,10 @@ module.exports = function(RED) {
                         node.send({
                             payload: payload,
                         });
-                        onPayloadDecoded(payload);
                     } else {
                         node.send({
                             payload: data.toString(),
                         });
-                        onPayloadDecoded(data.toString());
                     }
                 }
 

--- a/coap/coap-request.js
+++ b/coap/coap-request.js
@@ -35,50 +35,35 @@ module.exports = function(RED) {
             return payload;
         }
 
-        function _onCborDecode(err, data) {
-            if (err) {
-                return false;
-            }
-            var payload = data[0];
-            node.send({
-                payload: payload,
-            });
-        }
-
         function _makeRequest(msg) {
             var reqOpts = url.parse(node.options.url || msg.url);
             reqOpts.method = ( node.options.method || msg.method || 'GET' ).toUpperCase();
             reqOpts.headers = {};
             reqOpts.headers['Content-Format'] = node.options.contentFormat;
 
+            function _send(payload) {
+                node.send(Object.assign({}, msg, { payload: payload }));
+            }
+
             function _onResponse(res) {
                 function _onResponseData(data) {
-                    var payload = null;
                     if ( node.options.rawBuffer ) {
-                        node.send({
-                            payload: data,
-                        });
+                        _send(data);
                     } else if (res.headers['Content-Format'] === 'text/plain') {
-                        payload = data.toString();
-                        node.send({
-                            payload: payload,
-                        });
+                        _send(data.toString());
                     } else if (res.headers['Content-Format'] === 'application/json') {
-                        payload = JSON.parse(data.toString());
-                        node.send({
-                            payload: payload,
-                        });
+                        _send(JSON.parse(data.toString()));
                     } else if (res.headers['Content-Format'] === 'application/cbor') {
-                        cbor.decodeAll(data, _onCborDecode);
+                        cbor.decodeAll(data, function (err, data) {
+                            if (err) {
+                                return false;
+                            }
+                            _send(data[0]);
+                        });
                     } else if (res.headers['Content-Format'] === 'application/link-format') {
-                        payload = linkFormat.parse( data.toString() );
-                        node.send({
-                            payload: payload,
-                        });
+                        _send(linkFormat.parse(data.toString()));
                     } else {
-                        node.send({
-                            payload: data.toString(),
-                        });
+                        _send(data.toString());
                     }
                 }
 

--- a/test/coap-request_spec.js
+++ b/test/coap-request_spec.js
@@ -64,8 +64,8 @@ describe('CoapRequestNode', function() {
             { method: 'DELETE', message: 'Erase and rewind…' }
         ];
 
-        for ( i = 0; i < methodTests.length; ++i ) {
-            ( function ( test ) {
+        for (i = 0; i < methodTests.length; ++i) {
+            (function(test) {
                 it('should be able to make ' + test.method + ' requests', function(done) {
                     var port = getPort();
                     var flow = [
@@ -114,7 +114,7 @@ describe('CoapRequestNode', function() {
 
                     helper.load(testNodes, flow);
                 });
-            } ) ( methodTests[i] );
+            }) (methodTests[i]);
         }
 
         it('should use msg.method', function(done) {
@@ -390,19 +390,19 @@ describe('CoapRequestNode', function() {
             {
                 format: 'text/plain',
                 message: 'this is a plain text message.',
-                decode: function (buf) { return Promise.resolve(buf.toString()); }
+                decode: function(buf) { return Promise.resolve(buf.toString()); }
             },
             {
                 format: 'application/json',
                 message: { thisIs: 'JSON' },
-                decode: function (buf) { return Promise.resolve(JSON.parse(buf.toString())); }
+                decode: function(buf) { return Promise.resolve(JSON.parse(buf.toString())); }
             },
             {
                 format: 'application/cbor',
                 message: { thisIs: 'CBOR' },
-                decode: function (buf) { return new Promise( function (resolve, reject) {
-                    cbor.decodeFirst(buf,function (error, value) {
-                        if ( error ) {
+                decode: function(buf) { return new Promise(function(resolve, reject) {
+                    cbor.decodeFirst(buf, function(error, value) {
+                        if (error) {
                             reject(error);
                         } else {
                             resolve(value);
@@ -412,8 +412,8 @@ describe('CoapRequestNode', function() {
             }
         ];
 
-        for ( i = 0; i < serializeFormatTests.length; ++i ) {
-            ( function (test) {
+        for (i = 0; i < serializeFormatTests.length; ++i) {
+            (function(test) {
                 it('should be able to serialize `' + test.format + '` request payload', function(done) {
                     var port = getPort();
 
@@ -456,14 +456,14 @@ describe('CoapRequestNode', function() {
                     var testNodes = [coapRequestNode, injectNode];
                     helper.load(testNodes, flow);
                 });
-            } ) (serializeFormatTests[i]);
+            }) (serializeFormatTests[i]);
         }
 
         var deserializeFormatTests = [
             {
                 format: 'text/plain',
                 message: 'this is a plain text message.',
-                encode: function (s) { return s; }
+                encode: function(s) { return s; }
             },
             {
                 format: 'application/json',
@@ -478,12 +478,12 @@ describe('CoapRequestNode', function() {
             {
                 format: 'application/link-format',
                 message: linkFormat.parse('</r1>;if=foo;rt=bar,</r2>;if=foo;rt=baz;obs'),
-                encode: function (lf) { return lf.toString(); }
+                encode: function(lf) { return lf.toString(); }
             }
         ];
 
-        for ( i = 0; i < deserializeFormatTests.length; ++i ) {
-            ( function (test) {
+        for (i = 0; i < deserializeFormatTests.length; ++i) {
+            (function(test) {
                 it('should be able to deserialize `' + test.format + '` response payload', function(done) {
                     var port = getPort();
 
@@ -533,7 +533,7 @@ describe('CoapRequestNode', function() {
                     var testNodes = [coapRequestNode, injectNode, endTestNode];
                     helper.load(testNodes, flow);
                 });
-            } ) (deserializeFormatTests[i]);
+            }) (deserializeFormatTests[i]);
         }
 
         it('should return raw buffer if configured to', function(done) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -112,5 +112,18 @@ module.exports = {
             fn();
         } catch (e) { r = e; }
         done(r);
-    }
+    },
+
+    endTestNode: function(done, fn) {
+        return function endNode(RED) {
+            function EndTestNode(n) {
+                RED.nodes.createNode(this, n);
+                this.on('input', function(msg) {
+                    module.exports.endTest(done, fn.bind(null, msg));
+                });
+            }
+
+            RED.nodes.registerType("end-test-node", EndTestNode);
+        };
+    },
 };


### PR DESCRIPTION
This preserves message properties when traversing the request node, following an advice in th Node-RED documentation (not exactly the way the do, because of `Observe`).

It removes the `onPayloadDecoded`, too, using standard Node-RED flow to achieve the same thing in tests.