### PR TITLE
Export headers

### DIFF
--- a/coap/coap-request.js
+++ b/coap/coap-request.js
@@ -41,11 +41,15 @@ module.exports = function(RED) {
             reqOpts.headers = {};
             reqOpts.headers['Content-Format'] = node.options.contentFormat;
 
-            function _send(payload) {
-                node.send(Object.assign({}, msg, { payload: payload }));
-            }
-
             function _onResponse(res) {
+
+                function _send(payload) {
+                    node.send(Object.assign({}, msg, {
+                        payload: payload,
+                        headers: res.headers,
+                    }));
+                }
+
                 function _onResponseData(data) {
                     if ( node.options.rawBuffer ) {
                         _send(data);

--- a/coap/coap-request.js
+++ b/coap/coap-request.js
@@ -47,6 +47,7 @@ module.exports = function(RED) {
                     node.send(Object.assign({}, msg, {
                         payload: payload,
                         headers: res.headers,
+                        statusCode: res.code,
                     }));
                 }
 

--- a/test/coap-request_spec.js
+++ b/test/coap-request_spec.js
@@ -221,6 +221,52 @@ describe('CoapRequestNode', function() {
             helper.load(testNodes, flow);
         });
 
+        it('should export status', function(done) {
+            var port = getPort();
+            var flow = [
+                        {
+                            id: "inject",
+                            type: "inject",
+                            name: "inject",
+                            payload: "",
+                            payloadType: "none",
+                            repeat: "",
+                            crontab: "",
+                            once: true,
+                            wires: [["coapRequest"]],
+                        },
+                        {
+                            id: "coapRequest",
+                            type: "coap request",
+                            "content-format": "text/plain",
+                            method: "GET",
+                            name: "coapRequest",
+                            observe: false,
+                            url: "coap://localhost:" + port + "/test-resource",
+                            wires: [["end-test-node"]]
+                        },
+                        {
+                            id: "end-test-node",
+                            type: "end-test-node",
+                            name: "end-test-node",
+                        },
+                       ];
+
+            var endTestNode = helper.endTestNode(done, function(msg) {
+                msg.should.have.property('statusCode', '4.01');
+            });
+
+            var testNodes = [coapRequestNode, injectNode, changeNode, endTestNode];
+
+            var server = coap.createServer();
+            server.on('request', function(req, res) {
+                res.code = '4.01';
+                res.end('anything');
+            });
+            server.listen(port);
+            helper.load(testNodes, flow);
+        });
+
         it('should export headers', function(done) {
             var port = getPort();
             var flow = [

--- a/test/coap-request_spec.js
+++ b/test/coap-request_spec.js
@@ -208,13 +208,62 @@ describe('CoapRequestNode', function() {
                        ];
 
             var endTestNode = helper.endTestNode(done, function(msg) {
-                should(msg.random_property).equal("I will survive");
+                msg.should.have.property('random_property', 'I will survive');
             });
 
             var testNodes = [coapRequestNode, injectNode, changeNode, endTestNode];
 
             var server = coap.createServer();
             server.on('request', function(req, res) {
+                res.end('anything');
+            });
+            server.listen(port);
+            helper.load(testNodes, flow);
+        });
+
+        it('should export headers', function(done) {
+            var port = getPort();
+            var flow = [
+                        {
+                            id: "inject",
+                            type: "inject",
+                            name: "inject",
+                            payload: "",
+                            payloadType: "none",
+                            repeat: "",
+                            crontab: "",
+                            once: true,
+                            wires: [["coapRequest"]],
+                        },
+                        {
+                            id: "coapRequest",
+                            type: "coap request",
+                            "content-format": "text/plain",
+                            method: "GET",
+                            name: "coapRequest",
+                            observe: false,
+                            url: "coap://localhost:" + port + "/test-resource",
+                            wires: [["end-test-node"]]
+                        },
+                        {
+                            id: "end-test-node",
+                            type: "end-test-node",
+                            name: "end-test-node",
+                        },
+                       ];
+
+            var etag = "@etag@";
+
+            var endTestNode = helper.endTestNode(done, function(msg) {
+                msg.should.have.property('headers')
+                    .with.property('ETag', etag);
+            });
+
+            var testNodes = [coapRequestNode, injectNode, changeNode, endTestNode];
+
+            var server = coap.createServer();
+            server.on('request', function(req, res) {
+                res.setOption('ETag', etag);
                 res.end('anything');
             });
             server.listen(port);


### PR DESCRIPTION
Still following the way the HTTP node does, exporting status code and headers.

Recognized headers are unfortunately limited right now, but this is an issue with the CoAP library and I am working on it (mcollina/node-coap#126 and potentially more, as my needs evolve).