### PR TITLE
Replace basic 'url' library with 'uri-js'

### DIFF
--- a/coap/coap-request.js
+++ b/coap/coap-request.js
@@ -3,7 +3,7 @@ module.exports = function(RED) {
 
     var coap = require('coap');
     var cbor = require('cbor');
-    var url = require('url');
+    var url = require('uri-js');
     var linkFormat = require('h5.linkformat');
 
     coap.registerFormat('application/cbor', 60);
@@ -37,6 +37,7 @@ module.exports = function(RED) {
 
         function _makeRequest(msg) {
             var reqOpts = url.parse(node.options.url || msg.url);
+            reqOpts.pathname = reqOpts.path;
             reqOpts.method = ( node.options.method || msg.method || 'GET' ).toUpperCase();
             reqOpts.headers = {};
             reqOpts.headers['Content-Format'] = node.options.contentFormat;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "cbor": "^1.0.4",
     "coap": "^0.16.0",
-    "h5.linkformat": "0.0.0"
+    "h5.linkformat": "0.0.0",
+    "uri-js": "^3.0.2"
   },
   "devDependencies": {
     "express": "^4.13.4",


### PR DESCRIPTION
The basic `url` library in nodejs does not handle correctly IPv6
addresses.  `uri-js` handles the basic IPv6 addresses just fine.
This two-line change allows literal IPv6 URLs to be used in COAP
URLs, as long as the '%interface' suffices are not used.

For example, with this a coap-request node with the URL
coap://[fe80::da80:39ff:fe02:d171]/a/D0
works just fine, while without this change it does not.

There is now also a patched version of the `uri-js` library
available at https://github.com/Ell-i/uri-js, with a pull request
at https://github.com/garycourt/uri-js/pull/22